### PR TITLE
Avoid hard-coding a list of Linux architectures

### DIFF
--- a/MP/Makefile
+++ b/MP/Makefile
@@ -6,7 +6,7 @@
 
 COMPILE_PLATFORM=$(shell uname|sed -e s/_.*//|tr '[:upper:]' '[:lower:]'|sed -e 's/\//_/g')
 
-COMPILE_ARCH=$(shell uname -m | sed -e s/i.86/i386/)
+COMPILE_ARCH=$(shell uname -m | sed -e s/i.86/i386/ | sed -e 's/^arm.*/arm/')
 
 ifeq ($(COMPILE_PLATFORM),sunos)
   # Solaris uname and GNU uname differ

--- a/MP/Makefile
+++ b/MP/Makefile
@@ -355,30 +355,12 @@ endif
 #############################################################################
 
 ## Defaults
-LIB=lib
-
 INSTALL=install
 MKDIR=mkdir
 EXTRA_FILES=
 CLIENT_EXTRA_FILES=
 
 ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
-
-  ifeq ($(ARCH),x86_64)
-    LIB=lib64
-  else
-  ifeq ($(ARCH),ppc64)
-    LIB=lib64
-  else
-  ifeq ($(ARCH),s390x)
-    LIB=lib64
-  else
-  ifeq ($(ARCH),aarch64)
-    LIB=lib64
-  endif
-  endif
-  endif
-  endif
 
   BASE_CFLAGS = -Wall -fno-strict-aliasing \
     -pipe -DUSE_ICON
@@ -908,6 +890,7 @@ else # ifeq netbsd
 #############################################################################
 
 ifeq ($(PLATFORM),irix64)
+  LIB=lib
 
   ARCH=mips
 

--- a/MP/Makefile
+++ b/MP/Makefile
@@ -360,10 +360,14 @@ MKDIR=mkdir
 EXTRA_FILES=
 CLIENT_EXTRA_FILES=
 
+ifneq (,$(findstring "$(COMPILE_PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
+  TOOLS_CFLAGS += -DARCH_STRING=\"$(COMPILE_ARCH)\"
+endif
+
 ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
 
   BASE_CFLAGS = -Wall -fno-strict-aliasing \
-    -pipe -DUSE_ICON
+    -pipe -DUSE_ICON -DARCH_STRING=\\\"$(FILE_ARCH)\\\"
   CLIENT_CFLAGS += $(SDL_CFLAGS)
 
   OPTIMIZEVM = -O3

--- a/MP/code/qcommon/q_platform.h
+++ b/MP/code/qcommon/q_platform.h
@@ -185,38 +185,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define PATH_SEP '/'
 
-#if defined __i386__
-#define ARCH_STRING "i386"
-#elif defined __x86_64__
+#if !defined(ARCH_STRING)
+# error ARCH_STRING should be defined by the Makefile
+#endif
+
+#if defined __x86_64__
 #undef idx64
 #define idx64 1
-#define ARCH_STRING "x86_64"
-#elif defined __powerpc64__
-#define ARCH_STRING "ppc64"
-#elif defined __powerpc__
-#define ARCH_STRING "ppc"
-#elif defined __s390__
-#define ARCH_STRING "s390"
-#elif defined __s390x__
-#define ARCH_STRING "s390x"
-#elif defined __ia64__
-#define ARCH_STRING "ia64"
-#elif defined __alpha__
-#define ARCH_STRING "alpha"
-#elif defined __sparc__
-#define ARCH_STRING "sparc"
-#elif defined __arm__
-#define ARCH_STRING "arm"
-#elif defined __aarch64__
-#define ARCH_STRING "aarch64"
-#elif defined __cris__
-#define ARCH_STRING "cris"
-#elif defined __hppa__
-#define ARCH_STRING "hppa"
-#elif defined __mips__
-#define ARCH_STRING "mips"
-#elif defined __sh__
-#define ARCH_STRING "sh"
 #endif
 
 #if __FLOAT_WORD_ORDER == __BIG_ENDIAN

--- a/SP/Makefile
+++ b/SP/Makefile
@@ -6,7 +6,7 @@
 
 COMPILE_PLATFORM=$(shell uname|sed -e s/_.*//|tr '[:upper:]' '[:lower:]'|sed -e 's/\//_/g')
 
-COMPILE_ARCH=$(shell uname -m | sed -e s/i.86/i386/)
+COMPILE_ARCH=$(shell uname -m | sed -e s/i.86/i386/ | sed -e 's/^arm.*/arm/')
 
 ifeq ($(COMPILE_PLATFORM),sunos)
   # Solaris uname and GNU uname differ

--- a/SP/Makefile
+++ b/SP/Makefile
@@ -347,30 +347,12 @@ endif
 #############################################################################
 
 ## Defaults
-LIB=lib
-
 INSTALL=install
 MKDIR=mkdir
 EXTRA_FILES=
 CLIENT_EXTRA_FILES=
 
 ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
-
-  ifeq ($(ARCH),x86_64)
-    LIB=lib64
-  else
-  ifeq ($(ARCH),ppc64)
-    LIB=lib64
-  else
-  ifeq ($(ARCH),s390x)
-    LIB=lib64
-  else
-  ifeq ($(ARCH),aarch64)
-    LIB=lib64
-  endif
-  endif
-  endif
-  endif
 
   BASE_CFLAGS = -Wall -fno-strict-aliasing \
     -pipe -DUSE_ICON
@@ -900,6 +882,7 @@ else # ifeq netbsd
 #############################################################################
 
 ifeq ($(PLATFORM),irix64)
+  LIB=lib
 
   ARCH=mips
 

--- a/SP/Makefile
+++ b/SP/Makefile
@@ -352,10 +352,14 @@ MKDIR=mkdir
 EXTRA_FILES=
 CLIENT_EXTRA_FILES=
 
+ifneq (,$(findstring "$(COMPILE_PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
+  TOOLS_CFLAGS += -DARCH_STRING=\"$(COMPILE_ARCH)\"
+endif
+
 ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
 
   BASE_CFLAGS = -Wall -fno-strict-aliasing \
-    -pipe -DUSE_ICON
+    -pipe -DUSE_ICON -DARCH_STRING=\\\"$(FILE_ARCH)\\\"
   CLIENT_CFLAGS += $(SDL_CFLAGS)
 
   OPTIMIZEVM = -O3

--- a/SP/code/qcommon/q_platform.h
+++ b/SP/code/qcommon/q_platform.h
@@ -185,38 +185,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define PATH_SEP '/'
 
-#if defined __i386__
-#define ARCH_STRING "i386"
-#elif defined __x86_64__
+#if !defined(ARCH_STRING)
+# error ARCH_STRING should be defined by the Makefile
+#endif
+
+#if defined __x86_64__
 #undef idx64
 #define idx64 1
-#define ARCH_STRING "x86_64"
-#elif defined __powerpc64__
-#define ARCH_STRING "ppc64"
-#elif defined __powerpc__
-#define ARCH_STRING "ppc"
-#elif defined __s390__
-#define ARCH_STRING "s390"
-#elif defined __s390x__
-#define ARCH_STRING "s390x"
-#elif defined __ia64__
-#define ARCH_STRING "ia64"
-#elif defined __alpha__
-#define ARCH_STRING "alpha"
-#elif defined __sparc__
-#define ARCH_STRING "sparc"
-#elif defined __arm__
-#define ARCH_STRING "arm"
-#elif defined __aarch64__
-#define ARCH_STRING "aarch64"
-#elif defined __cris__
-#define ARCH_STRING "cris"
-#elif defined __hppa__
-#define ARCH_STRING "hppa"
-#elif defined __mips__
-#define ARCH_STRING "mips"
-#elif defined __sh__
-#define ARCH_STRING "sh"
 #endif
 
 #if __FLOAT_WORD_ORDER == __BIG_ENDIAN


### PR DESCRIPTION
This is an iortcw equivalent of <https://github.com/ioquake/ioq3/pull/129>, which was already merged.

Until recently, ioquake3 required trivial code changes every time Linux developers get interested in running it on a new CPU, most recently https://github.com/ioquake/ioq3/pull/128 for ARM64 (aka aarch64). For the vast majority of CPUs, the only change is to add ARCH_STRING detection, which must be kept in sync with the ARCH from the Makefile (which is just uname -m, with one special case for the 32-bit x86 family).

This branch passes the FILE_ARCH from the Makefile directly to q_platform.h on Linux and other GNU platforms, making it unnecessary to change anything to support new CPUs in most cases. Code changes should now only be needed if the new CPU is relevant to non-GNU platforms (Windows, OS X, *BSD), if there is genuinely something weird and assumption-breaking about it, or if someone contributes a JIT to replace the lowest-common-denominator QVM interpreter on that platform.

Additionally, native builds on 32-bit ARM already didn't work: on typical ARM platforms, `uname -m` returns something like `armv5tel` or `armv6l` (analogous to `i586` or `i686`), whereas `ARCH_STRING` was simply `arm` (analogous to `i386`). This would result in iortcw compiling `qagame_sp_armv5tel.so` but looking for `qagame_sp_arm.so` at runtime, causing failure. The second commit changes the Makefile to replace `arm*` with `arm` when running `uname -m`.