### PR TITLE
Pick up date from SOURCE_DATE_EPOCH, for reproducible builds

### DIFF
--- a/MP/Makefile
+++ b/MP/Makefile
@@ -1172,6 +1172,11 @@ ifeq ($(USE_PBMD5),1)
   CLIENT_CFLAGS += -DUSE_PBMD5
 endif
 
+# https://reproducible-builds.org/specs/source-date-epoch/
+ifdef SOURCE_DATE_EPOCH
+  BASE_CFLAGS += -DPRODUCT_DATE=\\\"$(shell date --date="@$$SOURCE_DATE_EPOCH" "+%b %_d %Y" | sed -e 's/ /\\\ /'g)\\\"
+endif
+
 BASE_CFLAGS += -DPRODUCT_VERSION=\\\"$(VERSION)\\\"
 BASE_CFLAGS += -Wformat=2 -Wformat-security -Wno-format-nonliteral
 BASE_CFLAGS += -Wstrict-aliasing=2 -Wmissing-format-attribute

--- a/MP/code/game/g_main.c
+++ b/MP/code/game/g_main.c
@@ -168,7 +168,7 @@ cvarTable_t gameCvarTable[] = {
 
 	// noset vars
 	{ NULL, "gamename", GAMEVERSION, CVAR_SERVERINFO | CVAR_ROM, 0, qfalse  },
-	{ NULL, "gamedate", __DATE__, CVAR_ROM, 0, qfalse  },
+	{ NULL, "gamedate", PRODUCT_DATE, CVAR_ROM, 0, qfalse  },
 	{ &g_restarted, "g_restarted", "0", CVAR_ROM, 0, qfalse  },
 
 	// latched vars
@@ -1095,7 +1095,7 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 	if ( trap_Cvar_VariableIntegerValue( "g_gametype" ) != GT_SINGLE_PLAYER ) {
 		G_Printf( "------- Game Initialization -------\n" );
 		G_Printf( "gamename: %s\n", GAMEVERSION );
-		G_Printf( "gamedate: %s\n", __DATE__ );
+		G_Printf( "gamedate: %s\n", PRODUCT_DATE );
 	}
 
 	srand( randomSeed );

--- a/MP/code/qcommon/common.c
+++ b/MP/code/qcommon/common.c
@@ -2703,7 +2703,7 @@ void Com_Init( char *commandLine ) {
 	// TTimo gcc warning: variable `safeMode' might be clobbered by `longjmp' or `vfork'
 	volatile qboolean safeMode = qtrue;
 
-	Com_Printf( "%s %s %s\n", Q3_VERSION, PLATFORM_STRING, __DATE__ );
+	Com_Printf( "%s %s %s\n", Q3_VERSION, PLATFORM_STRING, PRODUCT_DATE );
 
 	if ( setjmp( abortframe ) ) {
 		Sys_Error( "Error during initialization" );
@@ -2829,8 +2829,8 @@ void Com_Init( char *commandLine ) {
 #endif
 	com_recommendedSet = Cvar_Get( "com_recommendedSet", "0", CVAR_ARCHIVE );
 
-	s = va( "%s %s %s", Q3_VERSION, PLATFORM_STRING, __DATE__ );
-	t = va( "%s %s %s", OLDVERSION, PLATFORM_STRING, __DATE__ );
+	s = va( "%s %s %s", Q3_VERSION, PLATFORM_STRING, PRODUCT_DATE );
+	t = va( "%s %s %s", OLDVERSION, PLATFORM_STRING, PRODUCT_DATE );
 	com_fsgame = Cvar_Get( "fs_game", "", CVAR_INIT | CVAR_SYSTEMINFO );
 	com_legacyversion = Cvar_Get( "com_legacyversion", "0", CVAR_ARCHIVE );
 

--- a/MP/code/qcommon/q_shared.h
+++ b/MP/code/qcommon/q_shared.h
@@ -94,6 +94,10 @@ If you have questions concerning this license or the applicable additional terms
   #define OLD_PRODUCT_VERSION "1.41-MP"
 #endif
 
+#ifndef PRODUCT_DATE
+#  define PRODUCT_DATE __DATE__
+#endif
+
 #define Q3_VERSION PRODUCT_NAME " " PRODUCT_VERSION
 #define OLDVERSION OLD_PRODUCT_NAME " " OLD_PRODUCT_VERSION
 

--- a/MP/code/sys/sys_main.c
+++ b/MP/code/sys/sys_main.c
@@ -553,7 +553,7 @@ void Sys_ParseArgs( int argc, char **argv )
 		if( !strcmp( argv[1], "--version" ) ||
 				!strcmp( argv[1], "-v" ) )
 		{
-			const char* date = __DATE__;
+			const char* date = PRODUCT_DATE;
 #ifdef DEDICATED
 			fprintf( stdout, Q3_VERSION " dedicated server (%s)\n", date );
 #else

--- a/SP/Makefile
+++ b/SP/Makefile
@@ -1149,6 +1149,11 @@ ifeq ($(USE_BLOOM),1)
   CLIENT_CFLAGS += -DUSE_BLOOM
 endif
 
+# https://reproducible-builds.org/specs/source-date-epoch/
+ifdef SOURCE_DATE_EPOCH
+  BASE_CFLAGS += -DPRODUCT_DATE=\\\"$(shell date --date="@$$SOURCE_DATE_EPOCH" "+%b %_d %Y" | sed -e 's/ /\\\ /'g)\\\"
+endif
+
 BASE_CFLAGS += -DPRODUCT_VERSION=\\\"$(VERSION)\\\"
 BASE_CFLAGS += -Wformat=2 -Wformat-security -Wno-format-nonliteral
 BASE_CFLAGS += -Wstrict-aliasing=2 -Wmissing-format-attribute

--- a/SP/code/game/g_main.c
+++ b/SP/code/game/g_main.c
@@ -148,7 +148,7 @@ cvarTable_t gameCvarTable[] = {
 
 	// noset vars
 	{ NULL, "gamename", GAMEVERSION, CVAR_SERVERINFO | CVAR_ROM, 0, qfalse  },
-	{ NULL, "gamedate", __DATE__, CVAR_ROM, 0, qfalse  },
+	{ NULL, "gamedate", PRODUCT_DATE, CVAR_ROM, 0, qfalse  },
 	{ &g_restarted, "g_restarted", "0", CVAR_ROM, 0, qfalse  },
 
 	// latched vars
@@ -1177,7 +1177,7 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 	if ( trap_Cvar_VariableIntegerValue( "g_gametype" ) != GT_SINGLE_PLAYER ) {
 		G_Printf( "------- Game Initialization -------\n" );
 		G_Printf( "gamename: %s\n", GAMEVERSION );
-		G_Printf( "gamedate: %s\n", __DATE__ );
+		G_Printf( "gamedate: %s\n", PRODUCT_DATE );
 	}
 
 	srand( randomSeed );

--- a/SP/code/qcommon/common.c
+++ b/SP/code/qcommon/common.c
@@ -2254,7 +2254,7 @@ void Com_Init( char *commandLine ) {
 	char    *s;
 	int	qport;
 
-	Com_Printf( "%s %s %s\n", Q3_VERSION, PLATFORM_STRING, __DATE__ );
+	Com_Printf( "%s %s %s\n", Q3_VERSION, PLATFORM_STRING, PRODUCT_DATE );
 
 	if ( setjmp( abortframe ) ) {
 		Sys_Error( "Error during initialization" );
@@ -2377,7 +2377,7 @@ void Com_Init( char *commandLine ) {
 
 	Cvar_Get( "savegame_loading", "0", CVAR_ROM );
 
-	s = va("%s %s %s", Q3_VERSION, PLATFORM_STRING, __DATE__ );
+	s = va("%s %s %s", Q3_VERSION, PLATFORM_STRING, PRODUCT_DATE );
 	com_version = Cvar_Get ("version", s, CVAR_ROM | CVAR_SERVERINFO );
 	com_gamename = Cvar_Get("com_gamename", GAMENAME_FOR_MASTER, CVAR_SERVERINFO | CVAR_INIT);
 	com_protocol = Cvar_Get("com_protocol", va("%i", PROTOCOL_VERSION), CVAR_SERVERINFO | CVAR_INIT);

--- a/SP/code/qcommon/q_shared.h
+++ b/SP/code/qcommon/q_shared.h
@@ -87,6 +87,10 @@ If you have questions concerning this license or the applicable additional terms
   #define PRODUCT_VERSION "1.42e"
 #endif
 
+#ifndef PRODUCT_DATE
+#  define PRODUCT_DATE __DATE__
+#endif
+
 #define Q3_VERSION PRODUCT_NAME " " PRODUCT_VERSION
 
 #define MAX_TEAMNAME		32

--- a/SP/code/sys/sys_main.c
+++ b/SP/code/sys/sys_main.c
@@ -553,7 +553,7 @@ void Sys_ParseArgs( int argc, char **argv )
 		if( !strcmp( argv[1], "--version" ) ||
 				!strcmp( argv[1], "-v" ) )
 		{
-			const char* date = __DATE__;
+			const char* date = PRODUCT_DATE;
 #ifdef DEDICATED
 			fprintf( stdout, Q3_VERSION " dedicated server (%s)\n", date );
 #else


### PR DESCRIPTION
The goal of reproducible builds is that a rebuild of the same source
code with the same compiler, libraries, etc. should result in the same
binaries. SOURCE_DATE_EPOCH provides a standard way for build systems
to fill in the date of the latest source change, typically from a git
commit or from metadata like the debian/changelog in Debian packages.

---

Similar to <https://github.com/ioquake/ioq3/pull/225>, please see that PR for more details.