### PR TITLE
BOTH: Added one more check to prevent menu openning in more edge cases

### DIFF
--- a/MP/code/ui/ui_main.c
+++ b/MP/code/ui/ui_main.c
@@ -7250,6 +7250,11 @@ void _UI_SetActiveMenu( uiMenuCommand_t menu ) {
 			return;
 
 		case UIMENU_INGAME:
+      		// AR: don't allow openning menu during loading 
+      		if ( trap_Cvar_VariableValue( "savegame_loading" ) || trap_Cvar_VariableValue( "g_reloading" ) ) { 
+				return;
+			}
+			// AR end
 			trap_Key_SetCatcher( KEYCATCH_UI );
 			UI_BuildPlayerList();
 			Menus_CloseAll();

--- a/SP/code/ui/ui_main.c
+++ b/SP/code/ui/ui_main.c
@@ -7076,7 +7076,8 @@ void _UI_SetActiveMenu( uiMenuCommand_t menu ) {
 			return;
 
 		case UIMENU_INGAME:
-			if ( trap_Cvar_VariableValue( "savegame_loading" ) ) {
+			// AR: don't allow openning menu during loading
+			if ( trap_Cvar_VariableValue( "savegame_loading" ) || trap_Cvar_VariableValue( "g_reloading" ) ) {
 				return;
 			}
 			trap_Cvar_Set( "cl_paused", "1" );


### PR DESCRIPTION
Not every possible place when menu shouldn't be openned were adressed by savegame_loading flag. g_reloading is sometimes set when savegame_loading isn't (eg. pregame screen). When hitting button in the right moment, it was possible to open it. This prevents it for good.