### PR TITLE
BOTH: Removed -ffast-math flag from Release builds + added stripping

### DIFF
--- a/MP/Makefile
+++ b/MP/Makefile
@@ -262,7 +262,7 @@ USE_YACC=0
 endif
 
 ifndef DEBUG_CFLAGS
-DEBUG_CFLAGS=-g -O0
+DEBUG_CFLAGS=-g -ggdb -O0
 endif
 
 ifndef USE_ANTIWALLHACK
@@ -381,15 +381,15 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
   CLIENT_CFLAGS += $(SDL_CFLAGS)
 
   OPTIMIZEVM = -O3
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   ifeq ($(ARCH),x86_64)
     OPTIMIZEVM = -O3
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
   endif
   ifeq ($(ARCH),x86)
     OPTIMIZEVM = -O3 -march=i586
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
   endif
   ifeq ($(ARCH),ppc)
     ALTIVEC_CFLAGS = -maltivec
@@ -406,8 +406,6 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
     OPTIMIZEVM += -mtune=ultrasparc3 -mv8plus
   endif
   ifeq ($(ARCH),alpha)
-    # According to http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=410555
-    # -ffast-math will cause the client to die with SIGFPE on Alpha
     OPTIMIZE = $(OPTIMIZEVM)
   endif
 
@@ -571,7 +569,7 @@ ifeq ($(PLATFORM),darwin)
     CLIENT_EXTRA_FILES += $(LIBSDIR)/macosx/libSDL2-2.0.0.dylib $(LIBSDIR)/macosx/libopenal.dylib
   endif
 
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   SHLIBEXT=dylib
   SHLIBCFLAGS=-fPIC -fno-common
@@ -659,12 +657,12 @@ ifdef MINGW
 
   ifeq ($(ARCH),x86_64)
     OPTIMIZEVM = -O3
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
     FILE_ARCH=x64
   endif
   ifeq ($(ARCH),x86)
     OPTIMIZEVM = -O3 -march=i586
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
   endif
 
   SHLIBEXT=dll
@@ -757,16 +755,16 @@ ifneq (,$(findstring "$(PLATFORM)", "freebsd" "openbsd" "netbsd"))
   CLIENT_CFLAGS += $(SDL_CFLAGS)
 
   OPTIMIZEVM = -O3
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   ifeq ($(ARCH),x86_64)
     OPTIMIZEVM = -O3
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
     FILE_ARCH = amd64
   endif
   ifeq ($(ARCH),x86)
     OPTIMIZEVM = -O3 -march=i586
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
   endif
   ifeq ($(ARCH),ppc)
     ALTIVEC_CFLAGS = -maltivec
@@ -783,8 +781,6 @@ ifneq (,$(findstring "$(PLATFORM)", "freebsd" "openbsd" "netbsd"))
     OPTIMIZEVM += -mtune=ultrasparc3 -mv8plus
   endif
   ifeq ($(ARCH),alpha)
-    # According to http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=410555
-    # -ffast-math will cause the client to die with SIGFPE on Alpha
     OPTIMIZE = $(OPTIMIZEVM)
   endif
 
@@ -878,7 +874,7 @@ ifeq ($(PLATFORM),sunos)
     CLIENT_LDFLAGS += -L/usr/X11/lib/NVIDIA -R/usr/X11/lib/NVIDIA
   endif
 
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   SHLIBEXT=so
   SHLIBCFLAGS=-fPIC
@@ -1004,9 +1000,9 @@ ifneq ($(BUILD_GAME_SO),0)
 	$(B)/$(BASEGAME)/ui_mp_$(SHLIBNAME)
    else
    TARGETS += \
-        $(B)/$(BASEGAME)/cgame.mp.$(SHLIBNAME) \
-        $(B)/$(BASEGAME)/qagame.mp.$(SHLIBNAME) \
-        $(B)/$(BASEGAME)/ui.mp.$(SHLIBNAME)
+    $(B)/$(BASEGAME)/cgame.mp.$(SHLIBNAME) \
+    $(B)/$(BASEGAME)/qagame.mp.$(SHLIBNAME) \
+    $(B)/$(BASEGAME)/ui.mp.$(SHLIBNAME)
    endif
   endif
 endif
@@ -1334,6 +1330,16 @@ else
   print_wrapped=$(print_list)
 endif
 
+# AR: define strip targets
+TARGETS_DONTSTRIP= \
+	$(B)/$(BASEGAME)/vm/cgame.mp.qvm \
+	$(B)/$(BASEGAME)/vm/qagame.mp.qvm \
+	$(B)/$(BASEGAME)/vm/ui.mp.qvm
+
+TARGETS_STRIP=$(filter-out $(TARGETS_DONTSTRIP),$(TARGETS))
+# AR end
+
+
 # Create the build directories, check libraries and print out
 # an informational message, then start building
 targets: makedirs
@@ -1388,6 +1394,16 @@ else
     endif
   endif
 endif
+# AR: add this to shrink release size
+ifeq ($(B),$(BR)) 
+	@echo ""
+	@echo "Stripping output files..."
+	$(call print_list, $(TARGETS_STRIP))
+	@strip $(TARGETS_STRIP)
+	@echo "Stripping done!"
+	@echo ""
+endif
+# AR end
 
 $(B).zip: $(TARGETS)
 	@rm -f $@

--- a/SP/Makefile
+++ b/SP/Makefile
@@ -259,7 +259,7 @@ USE_YACC=0
 endif
 
 ifndef DEBUG_CFLAGS
-DEBUG_CFLAGS=-g -O0
+DEBUG_CFLAGS=-g -ggdb -O0
 endif
 
 ifndef USE_BLOOM
@@ -370,15 +370,15 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
   CLIENT_CFLAGS += $(SDL_CFLAGS)
 
   OPTIMIZEVM = -O3
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   ifeq ($(ARCH),x86_64)
     OPTIMIZEVM = -O3
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
   endif
   ifeq ($(ARCH),x86)
     OPTIMIZEVM = -O3 -march=i586
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
   endif
   ifeq ($(ARCH),ppc)
     ALTIVEC_CFLAGS = -maltivec
@@ -395,8 +395,6 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
     OPTIMIZEVM += -mtune=ultrasparc3 -mv8plus
   endif
   ifeq ($(ARCH),alpha)
-    # According to http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=410555
-    # -ffast-math will cause the client to die with SIGFPE on Alpha
     OPTIMIZE = $(OPTIMIZEVM)
   endif
 
@@ -560,7 +558,7 @@ ifeq ($(PLATFORM),darwin)
     CLIENT_EXTRA_FILES += $(LIBSDIR)/macosx/libSDL2-2.0.0.dylib $(LIBSDIR)/macosx/libopenal.dylib
   endif
 
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   SHLIBEXT=dylib
   SHLIBCFLAGS=-fPIC -fno-common
@@ -648,12 +646,12 @@ ifdef MINGW
 
   ifeq ($(ARCH),x86_64)
     OPTIMIZEVM = -O3
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
     FILE_ARCH=x64
   endif
   ifeq ($(ARCH),x86)
     OPTIMIZEVM = -O3 -march=i586
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
   endif
 
   SHLIBEXT=dll
@@ -746,16 +744,16 @@ ifneq (,$(findstring "$(PLATFORM)", "freebsd" "openbsd" "netbsd"))
   CLIENT_CFLAGS += $(SDL_CFLAGS)
 
   OPTIMIZEVM = -O3
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   ifeq ($(ARCH),x86_64)
     OPTIMIZEVM = -O3
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
     FILE_ARCH = amd64
   endif
   ifeq ($(ARCH),x86)
     OPTIMIZEVM = -O3 -march=i586
-    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+    OPTIMIZE = $(OPTIMIZEVM)
   endif
   ifeq ($(ARCH),ppc)
     ALTIVEC_CFLAGS = -maltivec
@@ -772,8 +770,6 @@ ifneq (,$(findstring "$(PLATFORM)", "freebsd" "openbsd" "netbsd"))
     OPTIMIZEVM += -mtune=ultrasparc3 -mv8plus
   endif
   ifeq ($(ARCH),alpha)
-    # According to http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=410555
-    # -ffast-math will cause the client to die with SIGFPE on Alpha
     OPTIMIZE = $(OPTIMIZEVM)
   endif
 
@@ -867,7 +863,7 @@ ifeq ($(PLATFORM),sunos)
     CLIENT_LDFLAGS += -L/usr/X11/lib/NVIDIA -R/usr/X11/lib/NVIDIA
   endif
 
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   SHLIBEXT=so
   SHLIBCFLAGS=-fPIC
@@ -1311,6 +1307,16 @@ else
   print_wrapped=$(print_list)
 endif
 
+# AR: define strip targets
+TARGETS_DONTSTRIP= \
+	$(B)/$(BASEGAME)/vm/cgame.mp.qvm \
+	$(B)/$(BASEGAME)/vm/qagame.mp.qvm \
+	$(B)/$(BASEGAME)/vm/ui.mp.qvm
+
+TARGETS_STRIP=$(filter-out $(TARGETS_DONTSTRIP),$(TARGETS))
+# AR end
+
+
 # Create the build directories, check libraries and print out
 # an informational message, then start building
 targets: makedirs
@@ -1365,6 +1371,16 @@ else
     endif
   endif
 endif
+# AR: add this to shrink release size
+ifeq ($(B),$(BR)) 
+	@echo ""
+	@echo "Stripping output files..."
+	$(call print_list, $(TARGETS_STRIP))
+	@strip $(TARGETS_STRIP)
+	@echo "Stripping done!"
+	@echo ""
+endif
+# AR end
 
 $(B).zip: $(TARGETS)
 	@rm -f $@


### PR DESCRIPTION
-ffast-math is unsafe and can cause (and actually was causing) series of issues