### PR TITLE
Disable skipping cutscenes and fix long reload delay

### DIFF
--- a/SP/code/client/cl_keys.c
+++ b/SP/code/client/cl_keys.c
@@ -2243,19 +2243,16 @@ void CL_KeyDownEvent( int key, unsigned time )
 		if ( !( Key_GetCatcher( ) & ( KEYCATCH_UI | KEYCATCH_CONSOLE ) ) ) {    // let menu/console handle keys if necessary
 
 			// in cutscenes we need to handle keys specially (pausing not allowed in camera mode)
-			if ( (  key == K_ESCAPE ||
-					key == K_SPACE ||
-					key == K_ENTER ) && qtrue ) {
-				if ( qtrue ) {
-					CL_AddReliableCommand( "cameraInterrupt", qfalse );
-				}
+			if (  key == K_ESCAPE ||
+				  key == K_SPACE ||
+				  key == K_ENTER  ) {
+				// AR: uncomment this line to enable cutscene skipping (buggy)
+				//CL_AddReliableCommand( "cameraInterrupt", qfalse );
 				return;
 			}
 
 			// eat all keys
-			if ( qtrue ) {
-				return;
-			}
+			return;
 		}
 
 		if ( ( Key_GetCatcher( ) & KEYCATCH_CONSOLE ) && key == K_ESCAPE ) {

--- a/SP/code/game/ai_cast_script_actions.c
+++ b/SP/code/game/ai_cast_script_actions.c
@@ -2352,7 +2352,7 @@ qboolean AICast_ScriptAction_ChangeLevel( cast_state_t *cs, char *params ) {
 	trap_SendServerCommand( -1, va( "snd_fade 0 %d", 1000 + exitTime ) ); //----(SA)	added
 
 	// load the next map, after a delay
-	level.reloadDelayTime = level.time + 4000 + exitTime;
+	level.reloadDelayTime = level.time + 1000 + exitTime;
 	trap_Cvar_Set( "g_reloading", va( "%d", RELOAD_NEXTMAP_WAITING ) );
 
 	if ( endgame ) {


### PR DESCRIPTION
I think the title is self explanatory... 

Anyway, I feel I should clarify at least the reload delay part. As can be seen in this line [HERE](https://github.com/id-Software/RTCW-SP/blob/master/src/game/ai_cast_script_actions.c#L2365) from original vanilla source, reload delay in this source port is 3s longer, causing few problems (for one example, watch first cutscene of the game till the end without skipping with +3s delay and vanilla delay).

I don't know if it was prolonged for some reason here, but it seems to work without an issue with value dropped down to vanilla level.