### PR TITLE
Add support for FreeBSD/powerpc64

### DIFF
--- a/MP/code/qcommon/q_platform.h
+++ b/MP/code/qcommon/q_platform.h
@@ -229,6 +229,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define ARCH_STRING "amd64"
 #elif defined __axp__
 #define ARCH_STRING "alpha"
+#elif defined __powerpc64__
+#define ARCH_STRING "powerpc64"
 #endif
 
 #if BYTE_ORDER == BIG_ENDIAN

--- a/SP/code/qcommon/q_platform.h
+++ b/SP/code/qcommon/q_platform.h
@@ -229,6 +229,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define ARCH_STRING "amd64"
 #elif defined __axp__
 #define ARCH_STRING "alpha"
+#elif defined __powerpc64__
+#define ARCH_STRING "powerpc64"
 #endif
 
 #if BYTE_ORDER == BIG_ENDIAN


### PR DESCRIPTION
powerpc64 support on FreeBSD almost works, just need to define ARCH_STRING properly.