### PR TITLE
Fix manual pick up of chalice at end of map crypt2

### DIFF
--- a/MP/code/game/g_cmds.c
+++ b/MP/code/game/g_cmds.c
@@ -1904,6 +1904,22 @@ void Cmd_Activate_f( gentity_t *ent ) {
 		return;
 	}
 
+	traceEnt = &g_entities[ tr.entityNum ];
+
+	if ( traceEnt->classname && Q_stricmp( traceEnt->classname, "trigger_hurt" ) == 0 ) {
+		// ignore trigger_hurt so it's possible to pickup chalice (-1472 -3472 284) at the end of map crypt2
+		trap_Trace( &tr, tr.endpos, NULL, NULL, end, tr.entityNum, ( CONTENTS_SOLID | CONTENTS_BODY | CONTENTS_CORPSE | CONTENTS_TRIGGER ) );
+
+		// muzzle and trigger_hurt are in player bbox?
+		if ( tr.entityNum == ent->s.number ) {
+			return;
+		}
+	}
+
+	if ( tr.surfaceFlags & SURF_NOIMPACT ) {
+		return;
+	}
+
 	if ( tr.entityNum == ENTITYNUM_WORLD ) {
 		return;
 	}

--- a/MP/code/game/g_main.c
+++ b/MP/code/game/g_main.c
@@ -493,6 +493,19 @@ void G_CheckForCursorHints( gentity_t *ent ) {
 	trap_Trace( tr, offset, NULL, NULL, end, ps->clientNum, trace_contents );
 	// dhm - end
 
+	traceEnt = &g_entities[tr->entityNum];
+
+	if ( traceEnt->classname && Q_stricmp( traceEnt->classname, "trigger_hurt" ) == 0 ) {
+		// ignore trigger_hurt so it's possible to pickup chalice (-1472 -3472 284) at the end of map crypt2
+		trap_Trace( tr, tr->endpos, NULL, NULL, end, tr->entityNum, trace_contents );
+
+		// muzzle and trigger_hurt are in player bbox?
+		if ( tr->entityNum == ps->clientNum ) {
+			tr->entityNum = ENTITYNUM_NONE;
+			tr->fraction = 1;
+		}
+	}
+
 	// reset all
 	hintType    = ps->serverCursorHint      = HINT_NONE;
 	hintVal     = ps->serverCursorHintVal   = 0;

--- a/SP/code/game/g_cmds.c
+++ b/SP/code/game/g_cmds.c
@@ -1494,6 +1494,22 @@ void Cmd_Activate_f( gentity_t *ent ) {
 
 	traceEnt = &g_entities[ tr.entityNum ];
 
+	if ( traceEnt->classname && Q_stricmp( traceEnt->classname, "trigger_hurt" ) == 0 ) {
+		// ignore trigger_hurt so it's possible to pickup chalice (-1472 -3472 284) at the end of map crypt2
+		trap_Trace( &tr, tr.endpos, NULL, NULL, end, tr.entityNum, ( CONTENTS_SOLID | CONTENTS_BODY | CONTENTS_CORPSE | CONTENTS_TRIGGER ) );
+
+		// muzzle and trigger_hurt are in player bbox?
+		if ( tr.entityNum == ent->s.number ) {
+			return;
+		}
+	}
+
+	if ( tr.surfaceFlags & SURF_NOIMPACT ) {
+		return;
+	}
+
+	traceEnt = &g_entities[ tr.entityNum ];
+
 	// G_Printf( "%s activate %s\n", ent->classname, traceEnt->classname);
 
 	// Ridah, check for using a friendly AI

--- a/SP/code/game/g_main.c
+++ b/SP/code/game/g_main.c
@@ -476,6 +476,19 @@ void G_CheckForCursorHints( gentity_t *ent ) {
 	trace_contents = ( CONTENTS_TRIGGER | CONTENTS_SOLID | CONTENTS_PLAYERCLIP | CONTENTS_BODY | CONTENTS_CORPSE );   // SP fine checking corpses
 	trap_Trace( tr, offset, NULL, NULL, end, ps->clientNum, trace_contents );
 
+	traceEnt = &g_entities[tr->entityNum];
+
+	if ( traceEnt->classname && Q_stricmp( traceEnt->classname, "trigger_hurt" ) == 0 ) {
+		// ignore trigger_hurt so it's possible to pickup chalice (-1472 -3472 284) at the end of map crypt2
+		trap_Trace( tr, tr->endpos, NULL, NULL, end, tr->entityNum, trace_contents );
+
+		// muzzle and trigger_hurt are in player bbox?
+		if ( tr->entityNum == ps->clientNum ) {
+			tr->entityNum = ENTITYNUM_NONE;
+			tr->fraction = 1;
+		}
+	}
+
 	// reset all
 	hintType    = ps->serverCursorHint      = HINT_NONE;
 	hintVal     = ps->serverCursorHintVal   = 0;


### PR DESCRIPTION
Possible fix for https://github.com/iortcw/iortcw/issues/77.

The chalice (at -1472 -3472 284) at the end of crypt2 single-player map is inside of a trigger_hurt entity. If cg_autoactivate is 1 (the default), the chalice is picked up when touched. However with cg_autoactivate 0 it was not possible to pick up (activate) the chalice because game tries to activate the trigger_hurt entity.

Make hint cursor and +activate trace skip trigger_hurt entity.