### PR TITLE
Remove legacy stuff from Quake III Arena's scoreboard

### DIFF
--- a/MP/code/cgame/cg_scoreboard.c
+++ b/MP/code/cgame/cg_scoreboard.c
@@ -735,10 +735,6 @@ qboolean CG_DrawScoreboard( void ) {
 		CG_DrawBigStringColor( x, y, "SCORE PING TIME NAME", fadeColor );
 		CG_DrawBigStringColor( x, y + 12, "----- ---- ---- ---------------", fadeColor );
 	#endif
-		CG_DrawPic( x + 1 * 16, y, 64, 32, cgs.media.scoreboardScore );
-		CG_DrawPic( x + 6 * 16 + 8, y, 64, 32, cgs.media.scoreboardPing );
-		CG_DrawPic( x + 11 * 16 + 8, y, 64, 32, cgs.media.scoreboardTime );
-		CG_DrawPic( x + 16 * 16, y, 64, 32, cgs.media.scoreboardName );
 
 		y += 32;
 	}

--- a/SP/code/cgame/cg_scoreboard.c
+++ b/SP/code/cgame/cg_scoreboard.c
@@ -526,10 +526,6 @@ qboolean CG_DrawScoreboard( void ) {
 		CG_DrawBigStringColor( x, y, "SCORE PING TIME NAME", fadeColor );
 		CG_DrawBigStringColor( x, y + 12, "----- ---- ---- ---------------", fadeColor );
 	#endif
-		CG_DrawPic( x + 1 * 16, y, 64, 32, cgs.media.scoreboardScore );
-		CG_DrawPic( x + 6 * 16 + 8, y, 64, 32, cgs.media.scoreboardPing );
-		CG_DrawPic( x + 11 * 16 + 8, y, 64, 32, cgs.media.scoreboardTime );
-		CG_DrawPic( x + 16 * 16, y, 64, 32, cgs.media.scoreboardName );
 
 		y += 32;
 	}


### PR DESCRIPTION
**cgs.media.scoreboardScore**/**Ping**/**Time**/**Name** aren't even set up in RTCW... so they can just go unless someone gets around to simply draw text. Use the ingame HUD text font used for pickups or mission failure (if you want) in their place.