### PR TITLE
Fix launch crash while launching x64 .exe right after launching x86 .exe (or x86 after x64)

### DIFF
--- a/SP/code/client/snd_openal.c
+++ b/SP/code/client/snd_openal.c
@@ -2678,7 +2678,7 @@ qboolean S_AL_Init( soundInterface_t *si )
 	s_alGraceDistance = Cvar_Get("s_alGraceDistance", "512", CVAR_ARCHIVE);
 	s_alTalkAnims = Cvar_Get("s_alTalkAnims", "160", CVAR_ARCHIVE);
 
-	s_alDriver = Cvar_Get( "s_alDriver", ALDRIVER_DEFAULT, CVAR_ARCHIVE | CVAR_LATCH | CVAR_PROTECTED );
+	s_alDriver = Cvar_Get( "s_alDriver", ALDRIVER_DEFAULT, CVAR_LATCH | CVAR_PROTECTED );
 
 	s_alInputDevice = Cvar_Get( "s_alInputDevice", "", CVAR_ARCHIVE | CVAR_LATCH );
 	s_alDevice = Cvar_Get("s_alDevice", "", CVAR_ARCHIVE | CVAR_LATCH);


### PR DESCRIPTION
How to reproduce the crash:
1. Delete any old .cfgs
2. Launch x64 .exe and exit the game
2. Launch x86 .exe
3. Crash.

Works in both directions.

The issue is in the presence of **s_alDriver** in the .cfg file.

Removing **CVAR_ARCHIVE** flag helps and doesnt produce any other issues.

Fix is live on RealRTCW for a week or so.