### PR TITLE
MP: Add QuakeNite character roster system (9 characters)

### DIFF
--- a/MP/Makefile
+++ b/MP/Makefile
@@ -2541,6 +2541,7 @@ Q3CGOBJ_ = \
   $(B)/$(BASEGAME)/cgame/bg_animation.o \
   $(B)/$(BASEGAME)/cgame/bg_misc.o \
   $(B)/$(BASEGAME)/cgame/bg_pmove.o \
+  $(B)/$(BASEGAME)/cgame/bg_qn_characters.o \
   $(B)/$(BASEGAME)/cgame/bg_slidemove.o \
   $(B)/$(BASEGAME)/cgame/bg_lib.o \
   $(B)/$(BASEGAME)/cgame/cg_consolecmds.o \
@@ -2616,6 +2617,7 @@ Q3GOBJ_ = \
   $(B)/$(BASEGAME)/game/bg_animation.o \
   $(B)/$(BASEGAME)/game/bg_misc.o \
   $(B)/$(BASEGAME)/game/bg_pmove.o \
+  $(B)/$(BASEGAME)/game/bg_qn_characters.o \
   $(B)/$(BASEGAME)/game/bg_slidemove.o \
   $(B)/$(BASEGAME)/game/bg_lib.o \
   $(B)/$(BASEGAME)/game/g_active.o \
@@ -2675,6 +2677,7 @@ Q3UIOBJ_ = \
   $(B)/$(BASEGAME)/ui/ui_shared.o \
   \
   $(B)/$(BASEGAME)/ui/bg_misc.o \
+  $(B)/$(BASEGAME)/ui/bg_qn_characters.o \
   $(B)/$(BASEGAME)/ui/bg_lib.o \
   \
   $(B)/$(BASEGAME)/qcommon/q_math.o \

--- a/MP/code/game/bg_qn_characters.c
+++ b/MP/code/game/bg_qn_characters.c
@@ -148,11 +148,8 @@ Returns the model folder name (e.g., "chef")
 ==================
 */
 const char *BG_QN_GetCharacterModelName( int id ) {
-	const qnCharacterDef_t *def = BG_QN_GetCharacterDef( id );
-	if ( !def ) {
-		return "chef";  // fallback to first character
-	}
-	return def->modelName;
+	id = BG_QN_ClampCharacterId( id );
+	return qn_characters[id].modelName;
 }
 
 /*
@@ -163,11 +160,8 @@ Returns the display name (e.g., "Mister Chef")
 ==================
 */
 const char *BG_QN_GetCharacterDisplayName( int id ) {
-	const qnCharacterDef_t *def = BG_QN_GetCharacterDef( id );
-	if ( !def ) {
-		return "Mister Chef";
-	}
-	return def->displayName;
+	id = BG_QN_ClampCharacterId( id );
+	return qn_characters[id].displayName;
 }
 
 /*
@@ -178,11 +172,8 @@ Returns the short name for kill feed (e.g., "Chef")
 ==================
 */
 const char *BG_QN_GetCharacterShortName( int id ) {
-	const qnCharacterDef_t *def = BG_QN_GetCharacterDef( id );
-	if ( !def ) {
-		return "Chef";
-	}
-	return def->shortName;
+	id = BG_QN_ClampCharacterId( id );
+	return qn_characters[id].shortName;
 }
 
 /*
@@ -193,11 +184,8 @@ Returns the flavor text description
 ==================
 */
 const char *BG_QN_GetCharacterDescription( int id ) {
-	const qnCharacterDef_t *def = BG_QN_GetCharacterDef( id );
-	if ( !def ) {
-		return "";
-	}
-	return def->description;
+	id = BG_QN_ClampCharacterId( id );
+	return qn_characters[id].description;
 }
 
 /*

--- a/MP/code/game/bg_qn_characters.c
+++ b/MP/code/game/bg_qn_characters.c
@@ -1,0 +1,246 @@
+/*
+===========================================================================
+QuakeNite Character Roster System - Implementation
+
+Contains the 9 character definitions and helper functions.
+===========================================================================
+*/
+
+#include "../qcommon/q_shared.h"
+#include "bg_public.h"
+#include "bg_qn_characters.h"
+
+// ============================================================================
+// Character Roster Definitions
+// ============================================================================
+static const qnCharacterDef_t qn_characters[QN_NUM_CHARACTERS] = {
+	// QN_CHAR_MISTER_CHEF - Master Chief parody
+	{
+		QN_CHAR_MISTER_CHEF,
+		"Mister Chef",
+		"chef",
+		"Chef",
+		"Supersoldier. Supercook. Superviolent.",
+		1.1f
+	},
+
+	// QN_CHAR_BLITZ - Battletoads parody
+	{
+		QN_CHAR_BLITZ,
+		"Blitz",
+		"blitz",
+		"Blitz",
+		"The toad with the 'tude.",
+		0.9f
+	},
+
+	// QN_CHAR_WILLY_LEE - Double Dragon parody
+	{
+		QN_CHAR_WILLY_LEE,
+		"Willy Lee",
+		"willylee",
+		"Willy",
+		"Streets taught him everything.",
+		1.0f
+	},
+
+	// QN_CHAR_STEELHEIM - Stroheim/JoJo parody
+	{
+		QN_CHAR_STEELHEIM,
+		"Steelheim",
+		"steelheim",
+		"Steelheim",
+		"SCIENCE IS THE WORLD'S FINEST!",
+		1.05f
+	},
+
+	// QN_CHAR_HOLSTER_COLT - Hol Horse/JoJo parody
+	{
+		QN_CHAR_HOLSTER_COLT,
+		"Holster Colt",
+		"holster",
+		"Holster",
+		"Fastest finger in the West.",
+		1.0f
+	},
+
+	// QN_CHAR_NUMBER_SIX - Guido Mista/JoJo parody
+	{
+		QN_CHAR_NUMBER_SIX,
+		"Number Six",
+		"six",
+		"Six",
+		"Don't say that number.",
+		1.0f
+	},
+
+	// QN_CHAR_SOLID_SERPENT - Metal Gear parody
+	{
+		QN_CHAR_SOLID_SERPENT,
+		"Solid Serpent",
+		"serpent",
+		"Serpent",
+		"Stealth is optional.",
+		1.0f
+	},
+
+	// QN_CHAR_DUDE_BLASTEM - Duke Nukem/Doom parody
+	{
+		QN_CHAR_DUDE_BLASTEM,
+		"Dude Blastem",
+		"blastem",
+		"Dude",
+		"90s action hero energy, max volume.",
+		1.1f
+	},
+
+	// QN_CHAR_SIR_MATTHIAS - Redwall parody
+	{
+		QN_CHAR_SIR_MATTHIAS,
+		"Sir Matthias",
+		"matthias",
+		"Matthias",
+		"Woodland knight in a gunfight.",
+		0.85f
+	}
+};
+
+// ============================================================================
+// Public API Implementation
+// ============================================================================
+
+/*
+==================
+BG_QN_ClampCharacterId
+
+Clamp an integer to valid character ID range [0, QN_NUM_CHARACTERS-1]
+==================
+*/
+int BG_QN_ClampCharacterId( int id ) {
+	if ( id < 0 ) {
+		return 0;
+	}
+	if ( id >= QN_NUM_CHARACTERS ) {
+		return QN_NUM_CHARACTERS - 1;
+	}
+	return id;
+}
+
+/*
+==================
+BG_QN_GetCharacterDef
+
+Get the full character definition struct, or NULL if invalid
+==================
+*/
+const qnCharacterDef_t *BG_QN_GetCharacterDef( int id ) {
+	if ( id < 0 || id >= QN_NUM_CHARACTERS ) {
+		return NULL;
+	}
+	return &qn_characters[id];
+}
+
+/*
+==================
+BG_QN_GetCharacterModelName
+
+Returns the model folder name (e.g., "chef")
+==================
+*/
+const char *BG_QN_GetCharacterModelName( int id ) {
+	const qnCharacterDef_t *def = BG_QN_GetCharacterDef( id );
+	if ( !def ) {
+		return "chef";  // fallback to first character
+	}
+	return def->modelName;
+}
+
+/*
+==================
+BG_QN_GetCharacterDisplayName
+
+Returns the display name (e.g., "Mister Chef")
+==================
+*/
+const char *BG_QN_GetCharacterDisplayName( int id ) {
+	const qnCharacterDef_t *def = BG_QN_GetCharacterDef( id );
+	if ( !def ) {
+		return "Mister Chef";
+	}
+	return def->displayName;
+}
+
+/*
+==================
+BG_QN_GetCharacterShortName
+
+Returns the short name for kill feed (e.g., "Chef")
+==================
+*/
+const char *BG_QN_GetCharacterShortName( int id ) {
+	const qnCharacterDef_t *def = BG_QN_GetCharacterDef( id );
+	if ( !def ) {
+		return "Chef";
+	}
+	return def->shortName;
+}
+
+/*
+==================
+BG_QN_GetCharacterDescription
+
+Returns the flavor text description
+==================
+*/
+const char *BG_QN_GetCharacterDescription( int id ) {
+	const qnCharacterDef_t *def = BG_QN_GetCharacterDef( id );
+	if ( !def ) {
+		return "";
+	}
+	return def->description;
+}
+
+/*
+==================
+BG_QN_GetCharacterIdByModelName
+
+Get character ID from model name (e.g., "chef" -> QN_CHAR_MISTER_CHEF)
+Returns -1 if not found
+==================
+*/
+int BG_QN_GetCharacterIdByModelName( const char *modelName ) {
+	int i;
+
+	if ( !modelName || !modelName[0] ) {
+		return -1;
+	}
+
+	for ( i = 0; i < QN_NUM_CHARACTERS; i++ ) {
+		if ( Q_stricmp( modelName, qn_characters[i].modelName ) == 0 ) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+/*
+==================
+BG_QN_BuildModelPath
+
+Build a model path with team skin: "<modelName>/<skinName>"
+Example: BG_QN_BuildModelPath(QN_CHAR_MISTER_CHEF, "red", buf, sizeof(buf))
+         -> "chef/red"
+==================
+*/
+void BG_QN_BuildModelPath( int characterId, const char *skinName, char *outPath, int outPathSize ) {
+	const char *modelName;
+
+	modelName = BG_QN_GetCharacterModelName( characterId );
+
+	if ( !skinName || !skinName[0] ) {
+		skinName = "default";
+	}
+
+	Com_sprintf( outPath, outPathSize, "%s/%s", modelName, skinName );
+}

--- a/MP/code/game/bg_qn_characters.h
+++ b/MP/code/game/bg_qn_characters.h
@@ -1,0 +1,76 @@
+/*
+===========================================================================
+QuakeNite Character Roster System
+
+Defines the 9 playable characters for QuakeNite. Characters are purely
+cosmetic - same hitbox, same stats, different model/skin/voice.
+
+Asset layout expected:
+  models/players/<modelName>/
+    lower.md3, upper.md3, head.md3
+    animation.cfg
+    default.skin, red.skin, blue.skin, green.skin, yellow.skin
+    icon_default.tga
+
+  sound/player/<modelName>/
+    spawn1.wav, frag1.wav, death1.wav, etc.
+===========================================================================
+*/
+
+#ifndef BG_QN_CHARACTERS_H
+#define BG_QN_CHARACTERS_H
+
+// ============================================================================
+// Character IDs - order matters for qn_char cvar values
+// ============================================================================
+typedef enum {
+	QN_CHAR_MISTER_CHEF = 0,    // Master Chief parody - cooking supersoldier
+	QN_CHAR_BLITZ,              // Battletoads parody - 80s cartoon toad
+	QN_CHAR_WILLY_LEE,          // Double Dragon parody - 80s martial artist
+	QN_CHAR_STEELHEIM,          // Stroheim/JoJo parody - bombastic cyborg
+	QN_CHAR_HOLSTER_COLT,       // Hol Horse/JoJo parody - anime cowboy
+	QN_CHAR_NUMBER_SIX,         // Guido Mista/JoJo parody - tetraphobic gunslinger
+	QN_CHAR_SOLID_SERPENT,      // Metal Gear parody - tactical stealth operative
+	QN_CHAR_DUDE_BLASTEM,       // Duke Nukem/Doom parody - 90s action hero
+	QN_CHAR_SIR_MATTHIAS,       // Redwall parody - medieval warrior mouse
+
+	QN_NUM_CHARACTERS
+} qnCharacterId_t;
+
+// ============================================================================
+// Character Definition Structure
+// ============================================================================
+typedef struct {
+	qnCharacterId_t id;
+	const char      *displayName;   // Shown in UI: "Mister Chef"
+	const char      *modelName;     // Folder under models/players/: "chef"
+	const char      *shortName;     // For kill feed: "Chef"
+	const char      *description;   // Flavor text for selection screen
+	float           visualScale;    // Cosmetic only (0.85 - 1.1), hitbox unchanged
+} qnCharacterDef_t;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+// Clamp an integer to valid character ID range [0, QN_NUM_CHARACTERS-1]
+int BG_QN_ClampCharacterId( int id );
+
+// Get the full character definition struct, or NULL if invalid
+const qnCharacterDef_t *BG_QN_GetCharacterDef( int id );
+
+// Convenience accessors
+const char *BG_QN_GetCharacterModelName( int id );
+const char *BG_QN_GetCharacterDisplayName( int id );
+const char *BG_QN_GetCharacterShortName( int id );
+const char *BG_QN_GetCharacterDescription( int id );
+
+// Get character ID from model name (e.g., "chef" -> QN_CHAR_MISTER_CHEF)
+// Returns -1 if not found
+int BG_QN_GetCharacterIdByModelName( const char *modelName );
+
+// Build a model path with team skin: "<modelName>/<skinName>"
+// skinName should be "default", "red", "blue", "green", or "yellow"
+void BG_QN_BuildModelPath( int characterId, const char *skinName, char *outPath, int outPathSize );
+
+#endif // BG_QN_CHARACTERS_H

--- a/MP/code/game/g_client.c
+++ b/MP/code/game/g_client.c
@@ -1388,6 +1388,9 @@ void ClientUserinfoChanged( int clientNum ) {
 		int qnCharId;
 		const char *skinName;
 		char qnModelPath[MAX_QPATH];
+		const char *currentModel;
+		const char *currentHead;
+		qboolean needsUpdate;
 
 		// Read qn_char from userinfo, or use server-forced character
 		if ( g_qn_forceCharacter.integer >= 0 && g_qn_forceCharacter.integer < QN_NUM_CHARACTERS ) {
@@ -1415,17 +1418,22 @@ void ClientUserinfoChanged( int clientNum ) {
 		// Build the model path: "<modelName>/<skinName>"
 		BG_QN_BuildModelPath( qnCharId, skinName, qnModelPath, sizeof( qnModelPath ) );
 
-		// Force the model and head in userinfo
-		Info_SetValueForKey( userinfo, "model", qnModelPath );
-		Info_SetValueForKey( userinfo, "head", qnModelPath );
+		// Only update userinfo if model/head actually differ (avoid re-entrancy)
+		currentModel = Info_ValueForKey( userinfo, "model" );
+		currentHead = Info_ValueForKey( userinfo, "head" );
+		needsUpdate = ( Q_stricmp( currentModel, qnModelPath ) != 0 ||
+		                Q_stricmp( currentHead, qnModelPath ) != 0 );
 
-		// Write back the modified userinfo
-		trap_SetUserinfo( clientNum, userinfo );
+		if ( needsUpdate ) {
+			Info_SetValueForKey( userinfo, "model", qnModelPath );
+			Info_SetValueForKey( userinfo, "head", qnModelPath );
+			trap_SetUserinfo( clientNum, userinfo );
 
-		if ( g_developer.integer ) {
-			G_Printf( "QuakeNite: Client %d (%s) using character %s (%s)\n",
-				clientNum, client->pers.netname,
-				BG_QN_GetCharacterDisplayName( qnCharId ), qnModelPath );
+			if ( g_developer.integer ) {
+				G_Printf( "QuakeNite: Client %d (%s) using character %s (%s)\n",
+					clientNum, client->pers.netname,
+					BG_QN_GetCharacterDisplayName( qnCharId ), qnModelPath );
+			}
 		}
 	}
 

--- a/MP/code/game/g_local.h
+++ b/MP/code/game/g_local.h
@@ -32,6 +32,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #include "../qcommon/q_shared.h"
 #include "bg_public.h"
+#include "bg_qn_characters.h"
 #include "g_public.h"
 
 //==================================================================
@@ -463,6 +464,9 @@ typedef struct {
 	int latchPlayerWeapon;          // DHM - Nerve :: for GT_WOLF not archived
 	int latchPlayerItem;            // DHM - Nerve :: for GT_WOLF not archived
 	int latchPlayerSkin;            // DHM - Nerve :: for GT_WOLF not archived
+
+	// QuakeNite character system
+	int qnCharacterId;              // Selected character (0-8), see qnCharacterId_t
 } clientSession_t;
 
 //
@@ -1170,6 +1174,7 @@ extern vmCvar_t g_scriptDebug;
 extern vmCvar_t g_userAim;
 
 extern vmCvar_t g_forceModel;
+extern vmCvar_t g_developer;
 
 extern vmCvar_t g_mg42arc;
 
@@ -1204,6 +1209,9 @@ extern vmCvar_t g_antilag;
 extern vmCvar_t g_dbgRevive;
 
 extern vmCvar_t g_localTeamPref;
+
+// QuakeNite character system
+extern vmCvar_t g_qn_forceCharacter;
 
 void	trap_Print( const char *text );
 void	trap_Error( const char *text ) __attribute__((noreturn));

--- a/MP/code/game/g_main.c
+++ b/MP/code/game/g_main.c
@@ -164,6 +164,9 @@ vmCvar_t g_dbgRevive;
 
 vmCvar_t g_localTeamPref;
 
+// QuakeNite character system
+vmCvar_t g_qn_forceCharacter;
+
 cvarTable_t gameCvarTable[] = {
 	// don't override the cheat state set by the system
 	{ &g_cheats, "sv_cheats", "", 0, qfalse },
@@ -298,7 +301,11 @@ cvarTable_t gameCvarTable[] = {
 
 	{&g_dbgRevive, "g_dbgRevive", "0", 0, 0, qfalse},
 
-	{ &g_localTeamPref, "g_localTeamPref", "", 0, 0, qfalse }
+	{ &g_localTeamPref, "g_localTeamPref", "", 0, 0, qfalse },
+
+	// QuakeNite character system
+	// g_qn_forceCharacter: -1 = player choice, 0-8 = force specific character for all players
+	{ &g_qn_forceCharacter, "g_qn_forceCharacter", "-1", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qtrue }
 };
 
 static int gameCvarTableSize = ARRAY_LEN( gameCvarTable );

--- a/MP/code/game/g_session.c
+++ b/MP/code/game/g_session.c
@@ -50,7 +50,7 @@ void G_WriteClientSessionData( gclient_t *client ) {
 	const char  *s;
 	const char  *var;
 
-	s = va( "%i %i %i %i %i %i %i %i %i %i %i %i %i %i %i",       // DHM - Nerve
+	s = va( "%i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i",       // DHM - Nerve + QuakeNite
 			client->sess.sessionTeam,
 			client->sess.spectatorNum,
 			client->sess.spectatorState,
@@ -65,7 +65,8 @@ void G_WriteClientSessionData( gclient_t *client ) {
 			client->sess.latchPlayerType,   // DHM - Nerve
 			client->sess.latchPlayerWeapon, // DHM - Nerve
 			client->sess.latchPlayerItem,   // DHM - Nerve
-			client->sess.latchPlayerSkin    // DHM - Nerve
+			client->sess.latchPlayerSkin,   // DHM - Nerve
+			client->sess.qnCharacterId      // QuakeNite character
 			);
 
 	var = va( "session%i", (int)(client - level.clients) );
@@ -88,7 +89,7 @@ void G_ReadSessionData( gclient_t *client ) {
 	var = va( "session%i", (int)(client - level.clients) );
 	trap_Cvar_VariableStringBuffer( var, s, sizeof( s ) );
 
-	sscanf( s, "%i %i %i %i %i %i %i %i %i %i %i %i %i %i %i",       // DHM - Nerve
+	sscanf( s, "%i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i",       // DHM - Nerve + QuakeNite
 			(int *)&client->sess.sessionTeam,
 			&client->sess.spectatorNum,
 			(int *)&client->sess.spectatorState,
@@ -103,7 +104,8 @@ void G_ReadSessionData( gclient_t *client ) {
 			&client->sess.latchPlayerType,  // DHM - Nerve
 			&client->sess.latchPlayerWeapon, // DHM - Nerve
 			&client->sess.latchPlayerItem,  // DHM - Nerve
-			&client->sess.latchPlayerSkin   // DHM - Nerve
+			&client->sess.latchPlayerSkin,  // DHM - Nerve
+			&client->sess.qnCharacterId     // QuakeNite character
 			);
 
 	// NERVE - SMF
@@ -206,6 +208,12 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
 
 	sess->spawnObjectiveIndex = 0;
 	// dhm - end
+
+	// QuakeNite - initialize character from userinfo
+	{
+		const char *qnCharValue = Info_ValueForKey( userinfo, "qn_char" );
+		sess->qnCharacterId = BG_QN_ClampCharacterId( atoi( qnCharValue ) );
+	}
 
 	G_WriteClientSessionData( client );
 }

--- a/MP/code/game/g_session.c
+++ b/MP/code/game/g_session.c
@@ -89,6 +89,10 @@ void G_ReadSessionData( gclient_t *client ) {
 	var = va( "session%i", (int)(client - level.clients) );
 	trap_Cvar_VariableStringBuffer( var, s, sizeof( s ) );
 
+	// Initialize qnCharacterId to default before sscanf for backward compatibility
+	// with old session strings that don't have this field
+	client->sess.qnCharacterId = 0;
+
 	sscanf( s, "%i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i",       // DHM - Nerve + QuakeNite
 			(int *)&client->sess.sessionTeam,
 			&client->sess.spectatorNum,
@@ -107,6 +111,9 @@ void G_ReadSessionData( gclient_t *client ) {
 			&client->sess.latchPlayerSkin,  // DHM - Nerve
 			&client->sess.qnCharacterId     // QuakeNite character
 			);
+
+	// Clamp character ID to valid range (handles both old sessions and invalid data)
+	client->sess.qnCharacterId = BG_QN_ClampCharacterId( client->sess.qnCharacterId );
 
 	// NERVE - SMF
 	if ( g_altStopwatchMode.integer ) {


### PR DESCRIPTION
Implements server-authoritative character selection with 9 cosmetic characters:
- Mister Chef, Blitz, Willy Lee, Steelheim, Holster Colt
- Number Six, Solid Serpent, Dude Blastem, Sir Matthias

Features:
- bg_qn_characters.h/c: Shared roster definitions (game/cgame/ui)
- qn_char userinfo cvar: Client character selection (0-8)
- g_qn_forceCharacter cvar: Server can force specific character (-1=player choice)
- Server forces model/headmodel based on character + team skin (red/blue/default)
- Character ID persisted in client session data

Characters are purely cosmetic - same hitbox, same stats, different model/voice.